### PR TITLE
Provide a mechanism to test api calls.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,25 @@ stories_from_iterations = iterations.first.stories
 api.reset!
 ```
 
+## Testing helpers
+
+We provide a TestClient that allows an application using the gem, not to worry
+about test calling API multiple times.
+
+Require dependencies to use this functionality are vcr and webmock. Also VCR is
+expected to be properly configured by the time the TestClient is used.
+
+### Example code
+
+```
+require 'pivotaltracker/api/test_client'
+
+PivotalTracker::API.configure do |config|
+  config.client = PivotalTracker::API::TestClient
+  ...
+end
+```
+
 ## Contributing
 
 1. Fork it ( https://github.com/[my-github-username]/pivotaltracker/fork )

--- a/lib/pivotaltracker/api/test_client.rb
+++ b/lib/pivotaltracker/api/test_client.rb
@@ -1,0 +1,23 @@
+require 'vcr'
+require 'webmock'
+
+module PivotalTracker
+  class API
+    class TestClient < ::PivotalTracker::API::Client
+      def get(endpoint, id, options={})
+        casette =  if id < 0
+          "non_existing"
+        else
+          "#{id}"
+        end
+
+        resource = endpoint.gsub('/', '')
+        casette.prepend("#{resource}")
+
+        VCR.use_cassette(casette) do
+          super(endpoint, id, options)
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,10 +2,9 @@ require "codeclimate-test-reporter"
 CodeClimate::TestReporter.start
 
 require 'pivotaltracker'
-require 'vcr'
 require 'byebug'
-require 'webmock'
 require 'support/test_api_setup'
+require 'pivotaltracker/api/test_client'
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
@@ -21,25 +20,4 @@ VCR.configure do |config|
   config.cassette_library_dir = File.join(__dir__, 'fixtures', 'vcr_cassettes')
   config.hook_into :webmock
   config.ignore_hosts 'codeclimate.com'
-end
-
-module PivotalTracker
-  class API
-    class TestClient < ::PivotalTracker::API::Client
-      def get(endpoint, id, options={})
-        casette =  if id < 0
-          "non_existing"
-        else
-          "#{id}"
-        end
-
-        resource = endpoint.gsub('/', '')
-        casette.prepend("#{resource}")
-
-        VCR.use_cassette(casette) do
-          super(endpoint, id, options)
-        end
-      end
-    end
-  end
 end


### PR DESCRIPTION
Expose PivotalTracker::API::TestClient as a replacement of normal client. It
allows to use vcr and webmock to avoid hitting API multiple times.

As a requirement, VCR needs to be setup before this can run properly.
